### PR TITLE
Fix CITATION.cff YAML

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Buchholz
     given-names: Rebecca
-    orcid: https://orcid.org/0000-0000-0000-0000
-title: rrbuchholz/pm25_atmosphere_analysis_2023: DOI setup for Sonoma County PM2.5 analysis
+    orcid: "https://orcid.org/0000-0001-8124-2455"
+title: "rrbuchholz/pm25_atmosphere_analysis_2023: DOI setup for Sonoma County PM2.5 analysis"
 version: v0.1.0
 date-released: 2023-08-16


### PR DESCRIPTION
- Adds double-quotes to the `title` key.
- Adds and ORCiD identifier.